### PR TITLE
Update for schema v0.2

### DIFF
--- a/bin/opws-validate
+++ b/bin/opws-validate
@@ -16,7 +16,7 @@ const toTest = {
   profiles: [],
   legacies: []
 };
-let schemaVersion = process.env.OPWS_SCHEMA_VERSION || 'v0.1';
+let schemaVersion = process.env.OPWS_SCHEMA_VERSION || 'v0.2';
 let schemaPath;
 let explicitType = null;
 let sniff = true;
@@ -70,6 +70,9 @@ schemaPath = schemaPath || path.join(opwsSchemataRoot, schemaVersion);
 const validators = {};
 const validatorPromises = [];
 
+// for validating against v0.1
+ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
+
 function initValidator(type) {
   if (toTest[type].length) {
     validatorPromises.push(
@@ -97,11 +100,6 @@ function validationErrorMessage(error) {
   }
 }
 
-function isNotNotesError(error) {
-  return !(error.keyword == 'additionalProperties' &&
-    error.params.additionalProperty == 'notes');
-}
-
 Promise.all(validatorPromises).then(()=>{
   const validationPromises = [];
   function validateFile(filename, type) {
@@ -119,12 +117,7 @@ Promise.all(validatorPromises).then(()=>{
         if (valid) {
           return {filename, valid};
         } else {
-          const schemaErrors = validator.errors.filter(isNotNotesError);
-          if (schemaErrors.length > 0) {
-            return {filename, valid, schemaErrors};
-          } else {
-            return {filename, valid: true};
-          }
+          return {filename, valid, schemaErrors: validator.errors};
         }
       });
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/opws/opws-validate#readme",
   "dependencies": {
-    "ajv": "^4.11.3",
+    "ajv": "^5.3.0",
     "chalk": "^1.1.3",
     "jbans": "^0.1.1",
     "js-yaml": "^3.8.1",


### PR DESCRIPTION
This removes the special case for filtering out .notes, which was
never specified in the v0.1 schema, but was considered "valid"
as a compromise with the existing data. In v0.2, most of the uses
for .notes are covered in new properties that *are* specified as
part of the schema: see opws/opws-schemata#1.

To validate documents that would have been previously considered
valid under this exemption, strict schema adherence must be disabled
with the `--loose` option. (Note that this will ignore any *other*
properties that are not defined by the schema as well.)

This closes issue #2.